### PR TITLE
🔨 REFACTOR: shared tsconfig

### DIFF
--- a/packages/oberoncms/core/tsconfig.json
+++ b/packages/oberoncms/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/oberoncms/sqlite/tsconfig.json
+++ b/packages/oberoncms/sqlite/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/development/tsconfig.json
+++ b/packages/plugins/development/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/flydrive/tsconfig.json
+++ b/packages/plugins/flydrive/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/pgsql/tsconfig.json
+++ b/packages/plugins/pgsql/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/turso/tsconfig.json
+++ b/packages/plugins/turso/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/uploadthing/tsconfig.json
+++ b/packages/plugins/uploadthing/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/plugins/vercel-postgres/tsconfig.json
+++ b/packages/plugins/vercel-postgres/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/tohuhono/dev/base.ts.config.json
+++ b/packages/tohuhono/dev/base.ts.config.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "buildOnSave": false,
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "removeComments": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
+    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["**/*.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tohuhono/dev/package.json
+++ b/packages/tohuhono/dev/package.json
@@ -30,6 +30,7 @@
     "LICENSE*"
   ],
   "exports": {
+    "./base.ts.config.json": "./base.ts.config.json",
     "./eslint.config": "./eslint/config.mjs",
     "./eslint-react.config": "./eslint/react.config.mjs",
     "./eslint-next.config": "./eslint/next.config.mjs",

--- a/packages/tohuhono/dev/src/vite.config.ts
+++ b/packages/tohuhono/dev/src/vite.config.ts
@@ -2,7 +2,12 @@
 // vite.config.js
 import { writeFile, mkdir } from "fs/promises"
 import { exec } from "child_process"
-import { createLogger, defineConfig, type Plugin as VitePlugin } from "vite"
+import {
+  type ResolveOptions,
+  createLogger,
+  defineConfig,
+  type Plugin as VitePlugin,
+} from "vite"
 import preserveDirectives from "rollup-preserve-directives"
 import fg from "fast-glob"
 import { externalizeDeps } from "vite-plugin-externalize-deps"
@@ -69,7 +74,10 @@ function parseEntryPoints(entryPoints: string[] = ["src/*.ts"]) {
   return Object.fromEntries(entities)
 }
 
-export function initConfig(entryPoints: string[] = ["src/*.ts", "src/*.tsx"]) {
+export function initConfig(
+  entryPoints: string[] = ["src/*.ts", "src/*.tsx"],
+  resolve?: ResolveOptions,
+) {
   const logger = createLogger()
 
   return defineConfig({
@@ -84,6 +92,7 @@ export function initConfig(entryPoints: string[] = ["src/*.ts", "src/*.tsx"]) {
         logger.info(msg, options)
       },
     },
+    resolve,
     plugins: [
       externalizeDeps(),
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error

--- a/packages/tohuhono/dev/tsconfig.json
+++ b/packages/tohuhono/dev/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "./base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/tohuhono/puck-blocks/tsconfig.json
+++ b/packages/tohuhono/puck-blocks/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/tohuhono/puck-rich-text/tsconfig.json
+++ b/packages/tohuhono/puck-rich-text/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/tohuhono/ui/tsconfig.json
+++ b/packages/tohuhono/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/tohuhono/utils/tsconfig.json
+++ b/packages/tohuhono/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@tohuhono/dev/base.ts.config.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,3 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
-  "buildOnSave": false,
-  "compileOnSave": false,
-  "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "lib": ["es2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true,
-    "removeComments": false,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "es2022",
-    "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "noImplicitAny": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
-  },
-  "include": ["**/*.config.ts"],
-  "exclude": ["node_modules", "dist"]
+  "extends": "@tohuhono/dev/base.ts.config.json"
 }


### PR DESCRIPTION
```turbo prune --docker``` doesn't recognize relative tsconfig extends
so I made it into its own repo, to prevent ```turbo``` failure

reproduce:

1- turbo prune --scope=<any-package> --docker
2- cd to ```out/full```
3- ```pnpm install```
4- ```pnpm build:packages```

observe error

  