### PR TITLE
chore: finalise ui typing and lint strictness

### DIFF
--- a/.changeset/green-experts-rest.md
+++ b/.changeset/green-experts-rest.md
@@ -1,0 +1,6 @@
+---
+"@tohuhono/dev": patch
+---
+
+Promote `tohuhono/no-type-assertion-except-object-keys` from warning to error in
+the shared ESLint config.

--- a/.changeset/no-forward-ref-ui.md
+++ b/.changeset/no-forward-ref-ui.md
@@ -1,0 +1,13 @@
+---
+"@tohuhono/ui": patch
+---
+
+Adopt React 19 ref-as-prop patterns across UI components by removing
+`forwardRef` wrappers.
+
+- Replaced `forwardRef` usage in component wrappers with plain function
+  components.
+- Updated component prop types to `ComponentPropsWithRef<...>` where refs should
+  be accepted.
+- Kept runtime behavior and component structure intact while simplifying the
+  public API surface.

--- a/.changeset/soft-cases-peel.md
+++ b/.changeset/soft-cases-peel.md
@@ -1,0 +1,13 @@
+---
+"@tohuhono/ui": patch
+"@tohuhono/utils": patch
+---
+
+Remove UI type assertions for Base UI class names and keep type-safety intact.
+
+- Replaced `as` assertions in `@tohuhono/ui` components with structural typing
+  and runtime guards.
+- Updated button/form/toaster internals to avoid unsafe assertions while
+  preserving behavior.
+- Enhanced `cn` in `@tohuhono/utils` to support state-based className functions
+  used by Base UI primitives.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ validated, instead perform the following tasks without further prompting:
   new changes.
 - Commit and push changes; the commit message should be concise; the changeset
   is the description.
-- Open a PR against `main`
+- Open a PR against `main` with auto-merge and squash
 
 # Follow-up docs
 

--- a/docs/CODESTYLE.md
+++ b/docs/CODESTYLE.md
@@ -16,9 +16,11 @@
 - Minimal typing: Prefer inference and structural typing; add explicit types
   only when they improve correctness or readability. Don’t use as (or extra type
   aliases) to silence errors; fix the source type instead.
-- When explicit types are needed, use existing exported library/parser types
-  instead of ad-hoc local type shapes.
-- Prefer implicit, inline types
+- Prefer implicit types
+- Use existing exported library/parser types instead of ad-hoc local type
+  shapes.
+- For function props, prefer inline parameter typing (including discriminated
+  unions).
 
 ## React
 

--- a/packages/tohuhono/dev/eslint/custom-rules.mjs
+++ b/packages/tohuhono/dev/eslint/custom-rules.mjs
@@ -53,6 +53,6 @@ export const tohuhonoCustomConfig = defineConfig({
   },
   rules: {
     "@typescript-eslint/consistent-type-assertions": "off",
-    "tohuhono/no-type-assertion-except-object-keys": ["warn"],
+    "tohuhono/no-type-assertion-except-object-keys": ["error"],
   },
 })

--- a/packages/tohuhono/ui/src/components/avatar.tsx
+++ b/packages/tohuhono/ui/src/components/avatar.tsx
@@ -1,51 +1,37 @@
 "use client"
 
-import { ElementRef, forwardRef } from "react"
 import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
-const Avatar = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Root>,
-  AvatarPrimitive.Root.Props
->(({ className, ...props }, ref) => (
+const Avatar = ({ className, ...props }: AvatarPrimitive.Root.Props) => (
   <AvatarPrimitive.Root
-    ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
-))
-Avatar.displayName = "Avatar"
+)
 
-const AvatarImage = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Image>,
-  AvatarPrimitive.Image.Props
->(({ className, ...props }, ref) => (
+const AvatarImage = ({ className, ...props }: AvatarPrimitive.Image.Props) => (
   <AvatarPrimitive.Image
-    ref={ref}
-    className={cn("aspect-square h-full w-full", className as ClassNameValue)}
+    className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
-))
-AvatarImage.displayName = "AvatarImage"
+)
 
-const AvatarFallback = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Fallback>,
-  AvatarPrimitive.Fallback.Props
->(({ className, ...props }, ref) => (
+const AvatarFallback = ({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) => (
   <AvatarPrimitive.Fallback
-    ref={ref}
     className={cn(
       "bg-muted flex h-full w-full items-center justify-center rounded-full",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
-))
-AvatarFallback.displayName = "AvatarFallback"
+)
 
 export { Avatar, AvatarImage, AvatarFallback }

--- a/packages/tohuhono/ui/src/components/button.tsx
+++ b/packages/tohuhono/ui/src/components/button.tsx
@@ -1,11 +1,6 @@
 "use client"
 import {
-  type ButtonHTMLAttributes,
-  Children,
-  cloneElement,
-  type ComponentProps,
-  forwardRef,
-  isValidElement,
+  type ComponentPropsWithRef,
   type ReactElement,
   type ReactNode,
 } from "react"
@@ -44,40 +39,44 @@ const buttonVariants = cva(
   },
 )
 
-export interface ButtonProps
-  extends
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children">,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-  children?: ReactNode
-}
+const Button = ({
+  className: classNameProp,
+  variant,
+  size,
+  asChild,
+  children,
+  ref,
+  ...props
+}: Omit<
+  ComponentPropsWithRef<typeof ButtonPrimitive>,
+  "children" | "className" | "render"
+> &
+  VariantProps<typeof buttonVariants> & {
+    className?: string
+  } & (
+    | { asChild: true; children: ReactElement }
+    | { asChild?: false; children?: ReactNode }
+  )) => {
+  const className = cn(
+    buttonVariants({ variant, size, className: classNameProp }),
+  )
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, children, ...props }, ref) => {
-    const classes = cn(buttonVariants({ variant, size, className }))
-
-    if (asChild) {
-      const child = Children.only(children)
-      if (!isValidElement(child)) return null
-      const childElement = child as ReactElement<{ className?: string }>
-
-      return cloneElement(childElement, {
-        className: cn(classes, childElement.props.className),
-        ...props,
-      })
-    }
-
+  if (asChild) {
     return (
       <ButtonPrimitive
         ref={ref}
-        className={classes}
-        {...(props as ComponentProps<typeof ButtonPrimitive>)}
-      >
-        {children}
-      </ButtonPrimitive>
+        className={className}
+        render={children}
+        {...props}
+      />
     )
-  },
-)
-Button.displayName = "Button"
+  }
+
+  return (
+    <ButtonPrimitive ref={ref} className={className} {...props}>
+      {children}
+    </ButtonPrimitive>
+  )
+}
 
 export { Button, buttonVariants }

--- a/packages/tohuhono/ui/src/components/card.tsx
+++ b/packages/tohuhono/ui/src/components/card.tsx
@@ -1,72 +1,41 @@
-import { HTMLAttributes, forwardRef } from "react"
+import { type ComponentPropsWithRef } from "react"
 
 import { cn } from "@tohuhono/utils"
 
-const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "bg-card text-card-foreground rounded-xl border shadow",
-        className,
-      )}
-      {...props}
-    />
-  ),
+const Card = ({ className, ...props }: ComponentPropsWithRef<"div">) => (
+  <div
+    className={cn(
+      "bg-card text-card-foreground rounded-xl border shadow",
+      className,
+    )}
+    {...props}
+  />
 )
-Card.displayName = "Card"
 
-const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("flex flex-col space-y-1.5 p-6", className)}
-      {...props}
-    />
-  ),
+const CardHeader = ({ className, ...props }: ComponentPropsWithRef<"div">) => (
+  <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
 )
-CardHeader.displayName = "CardHeader"
 
-const CardTitle = forwardRef<
-  HTMLParagraphElement,
-  HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+const CardTitle = ({ className, ...props }: ComponentPropsWithRef<"h3">) => (
   <h3
-    ref={ref}
     className={cn("leading-none font-semibold tracking-tight", className)}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
-
-const CardDescription = forwardRef<
-  HTMLParagraphElement,
-  HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p
-    ref={ref}
-    className={cn("text-muted-foreground text-sm", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
-
-const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-  ),
 )
-CardContent.displayName = "CardContent"
 
-const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("flex items-center p-6 pt-0", className)}
-      {...props}
-    />
-  ),
+const CardDescription = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"p">) => (
+  <p className={cn("text-muted-foreground text-sm", className)} {...props} />
 )
-CardFooter.displayName = "CardFooter"
+
+const CardContent = ({ className, ...props }: ComponentPropsWithRef<"div">) => (
+  <div className={cn("p-6 pt-0", className)} {...props} />
+)
+
+const CardFooter = ({ className, ...props }: ComponentPropsWithRef<"div">) => (
+  <div className={cn("flex items-center p-6 pt-0", className)} {...props} />
+)
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/packages/tohuhono/ui/src/components/checkbox.tsx
+++ b/packages/tohuhono/ui/src/components/checkbox.tsx
@@ -3,13 +3,12 @@
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Checkbox = ({ className, ...props }: CheckboxPrimitive.Root.Props) => (
   <CheckboxPrimitive.Root
     className={cn(
       "peer border-primary focus-visible:ring-ring data-[checked]:bg-primary data-[checked]:text-primary-foreground h-4 w-4 shrink-0 rounded-sm border shadow focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >

--- a/packages/tohuhono/ui/src/components/command.tsx
+++ b/packages/tohuhono/ui/src/components/command.tsx
@@ -1,38 +1,34 @@
 "use client"
 
 import {
-  ComponentProps,
-  ComponentPropsWithoutRef,
-  ElementRef,
-  HTMLAttributes,
-  ReactNode,
-  forwardRef,
+  type ComponentProps,
+  type ComponentPropsWithRef,
+  type ReactNode,
 } from "react"
 import { Command as CommandPrimitive } from "cmdk"
 
 import { cn } from "@tohuhono/utils"
 import { Dialog, DialogContent } from "./dialog"
 
-const Command = forwardRef<
-  ElementRef<typeof CommandPrimitive>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
+const Command = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive>) => (
   <CommandPrimitive
-    ref={ref}
     className={cn(
       "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
       className,
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
+)
 
-type CommandDialogProps = Omit<ComponentProps<typeof Dialog>, "children"> & {
+const CommandDialog = ({
+  children,
+  ...props
+}: Omit<ComponentProps<typeof Dialog>, "children"> & {
   children: ReactNode
-}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+}) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
@@ -44,10 +40,10 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   )
 }
 
-const CommandInput = forwardRef<
-  ElementRef<typeof CommandPrimitive.Input>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+const CommandInput = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive.Input>) => (
   <div className="flex items-center border-b px-3" data-cmdk-input-wrapper="">
     <svg
       viewBox="0 0 24 24"
@@ -71,7 +67,6 @@ const CommandInput = forwardRef<
       />
     </svg>
     <CommandPrimitive.Input
-      ref={ref}
       className={cn(
         "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50",
         className,
@@ -79,84 +74,62 @@ const CommandInput = forwardRef<
       {...props}
     />
   </div>
-))
+)
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
-
-const CommandList = forwardRef<
-  ElementRef<typeof CommandPrimitive.List>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
+const CommandList = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive.List>) => (
   <CommandPrimitive.List
-    ref={ref}
     className={cn("max-h-[300px] overflow-x-hidden overflow-y-auto", className)}
     {...props}
   />
-))
+)
 
-CommandList.displayName = CommandPrimitive.List.displayName
+const CommandEmpty = (
+  props: ComponentPropsWithRef<typeof CommandPrimitive.Empty>,
+) => <CommandPrimitive.Empty className="py-6 text-center text-sm" {...props} />
 
-const CommandEmpty = forwardRef<
-  ElementRef<typeof CommandPrimitive.Empty>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-  <CommandPrimitive.Empty
-    ref={ref}
-    className="py-6 text-center text-sm"
-    {...props}
-  />
-))
-
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
-
-const CommandGroup = forwardRef<
-  ElementRef<typeof CommandPrimitive.Group>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
+const CommandGroup = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive.Group>) => (
   <CommandPrimitive.Group
-    ref={ref}
     className={cn(
       "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
       className,
     )}
     {...props}
   />
-))
+)
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
-
-const CommandSeparator = forwardRef<
-  ElementRef<typeof CommandPrimitive.Separator>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const CommandSeparator = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive.Separator>) => (
   <CommandPrimitive.Separator
-    ref={ref}
     className={cn("bg-border -mx-1 h-px", className)}
     {...props}
   />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+)
 
-const CommandItem = forwardRef<
-  ElementRef<typeof CommandPrimitive.Item>,
-  ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+const CommandItem = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof CommandPrimitive.Item>) => (
   <CommandPrimitive.Item
-    ref={ref}
     className={cn(
       "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
       className,
     )}
     {...props}
   />
-))
-
-CommandItem.displayName = CommandPrimitive.Item.displayName
+)
 
 const CommandShortcut = ({
   className,
   ...props
-}: HTMLAttributes<HTMLSpanElement>) => {
+}: ComponentPropsWithRef<"span">) => {
   return (
     <span
       className={cn(
@@ -167,7 +140,6 @@ const CommandShortcut = ({
     />
   )
 }
-CommandShortcut.displayName = "CommandShortcut"
 
 export {
   Command,

--- a/packages/tohuhono/ui/src/components/dialog.tsx
+++ b/packages/tohuhono/ui/src/components/dialog.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import { ElementRef, HTMLAttributes, forwardRef } from "react"
+import { type HTMLAttributes } from "react"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Dialog = DialogPrimitive.Root
 
@@ -14,32 +13,30 @@ const DialogPortal = DialogPrimitive.Portal
 
 const DialogClose = DialogPrimitive.Close
 
-const DialogOverlay = forwardRef<
-  ElementRef<typeof DialogPrimitive.Backdrop>,
-  DialogPrimitive.Backdrop.Props
->(({ className, ...props }, ref) => (
+const DialogOverlay = ({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) => (
   <DialogPrimitive.Backdrop
-    ref={ref}
     className={cn(
       "data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = "DialogOverlay"
+)
 
-const DialogContent = forwardRef<
-  ElementRef<typeof DialogPrimitive.Popup>,
-  DialogPrimitive.Popup.Props
->(({ className, children, ...props }, ref) => (
+const DialogContent = ({
+  className,
+  children,
+  ...props
+}: DialogPrimitive.Popup.Props) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Popup
-      ref={ref}
       className={cn(
         "bg-background data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[closed]:slide-out-to-left-1/2 data-[closed]:slide-out-to-top-[48%] data-[open]:slide-in-from-left-1/2 data-[open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
-        className as ClassNameValue,
+        className,
       )}
       {...props}
     >
@@ -58,8 +55,7 @@ const DialogContent = forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Popup>
   </DialogPortal>
-))
-DialogContent.displayName = "DialogContent"
+)
 
 const DialogHeader = ({
   className,
@@ -68,12 +64,11 @@ const DialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
 )
-DialogHeader.displayName = "DialogHeader"
 
 const DialogFooter = ({
   className,
@@ -82,39 +77,31 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
 )
-DialogFooter.displayName = "DialogFooter"
 
-const DialogTitle = forwardRef<
-  ElementRef<typeof DialogPrimitive.Title>,
-  DialogPrimitive.Title.Props
->(({ className, ...props }, ref) => (
+const DialogTitle = ({ className, ...props }: DialogPrimitive.Title.Props) => (
   <DialogPrimitive.Title
-    ref={ref}
     className={cn(
       "text-lg leading-none font-semibold tracking-tight",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
-))
-DialogTitle.displayName = "DialogTitle"
+)
 
-const DialogDescription = forwardRef<
-  ElementRef<typeof DialogPrimitive.Description>,
-  DialogPrimitive.Description.Props
->(({ className, ...props }, ref) => (
+const DialogDescription = ({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) => (
   <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-muted-foreground text-sm", className as ClassNameValue)}
+    className={cn("text-muted-foreground text-sm", className)}
     {...props}
   />
-))
-DialogDescription.displayName = "DialogDescription"
+)
 
 export {
   Dialog,

--- a/packages/tohuhono/ui/src/components/dropdown-menu.tsx
+++ b/packages/tohuhono/ui/src/components/dropdown-menu.tsx
@@ -4,7 +4,6 @@ import { Children, HTMLAttributes, isValidElement } from "react"
 import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const DropdownMenu = MenuPrimitive.Root
 
@@ -44,7 +43,7 @@ const DropdownMenuSubTrigger = ({
     className={cn(
       "focus:bg-accent data-[popup-open]:bg-accent flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none",
       inset && "pl-8",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >
@@ -77,7 +76,7 @@ const DropdownMenuSubContent = ({
   <DropdownMenuContent
     className={cn(
       "data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem]",
-      className as ClassNameValue,
+      className,
     )}
     align={align}
     alignOffset={alignOffset}
@@ -111,7 +110,7 @@ const DropdownMenuContent = ({
         className={cn(
           "bg-popover text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
           "data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className as ClassNameValue,
+          className,
         )}
         {...props}
       />
@@ -130,7 +129,7 @@ const DropdownMenuItem = ({
     className={cn(
       "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       inset && "pl-8",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
@@ -145,7 +144,7 @@ const DropdownMenuCheckboxItem = ({
   <MenuPrimitive.CheckboxItem
     className={cn(
       "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     checked={checked}
     {...props}
@@ -176,7 +175,7 @@ const DropdownMenuRadioItem = ({
   <MenuPrimitive.RadioItem
     className={cn(
       "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >
@@ -206,7 +205,7 @@ const DropdownMenuLabel = ({
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
       inset && "pl-8",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
@@ -217,7 +216,7 @@ const DropdownMenuSeparator = ({
   ...props
 }: MenuPrimitive.Separator.Props) => (
   <MenuPrimitive.Separator
-    className={cn("bg-muted -mx-1 my-1 h-px", className as ClassNameValue)}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
     {...props}
   />
 )
@@ -228,10 +227,7 @@ const DropdownMenuShortcut = ({
 }: HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn(
-        "ml-auto text-xs tracking-widest opacity-60",
-        className as ClassNameValue,
-      )}
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
       {...props}
     />
   )

--- a/packages/tohuhono/ui/src/components/input-otp.tsx
+++ b/packages/tohuhono/ui/src/components/input-otp.tsx
@@ -1,21 +1,16 @@
 "use client"
 
-import {
-  ComponentPropsWithoutRef,
-  ElementRef,
-  forwardRef,
-  useContext,
-} from "react"
+import { type ComponentPropsWithRef, useContext } from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
 
 import { cn } from "@tohuhono/utils"
 
-const InputOTP = forwardRef<
-  ElementRef<typeof OTPInput>,
-  ComponentPropsWithoutRef<typeof OTPInput>
->(({ className, containerClassName, ...props }, ref) => (
+const InputOTP = ({
+  className,
+  containerClassName,
+  ...props
+}: ComponentPropsWithRef<typeof OTPInput>) => (
   <OTPInput
-    ref={ref}
     containerClassName={cn(
       "flex items-center gap-2 has-[:disabled]:opacity-50",
       containerClassName,
@@ -23,27 +18,25 @@ const InputOTP = forwardRef<
     className={cn("disabled:cursor-not-allowed", className)}
     {...props}
   />
-))
-InputOTP.displayName = "InputOTP"
+)
 
-const InputOTPGroup = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<"div">
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex items-center", className)} {...props} />
-))
-InputOTPGroup.displayName = "InputOTPGroup"
+const InputOTPGroup = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) => (
+  <div className={cn("flex items-center", className)} {...props} />
+)
 
-const InputOTPSlot = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<"div"> & { index: number }
->(({ index, className, ...props }, ref) => {
+const InputOTPSlot = ({
+  index,
+  className,
+  ...props
+}: ComponentPropsWithRef<"div"> & { index: number }) => {
   const inputOTPContext = useContext(OTPInputContext)
   const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
 
   return (
     <div
-      ref={ref}
       className={cn(
         "border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
         isActive && "ring-ring z-10 ring-1",
@@ -59,14 +52,10 @@ const InputOTPSlot = forwardRef<
       )}
     </div>
   )
-})
-InputOTPSlot.displayName = "InputOTPSlot"
+}
 
-const InputOTPSeparator = forwardRef<
-  ElementRef<"div">,
-  ComponentPropsWithoutRef<"div">
->(({ ...props }, ref) => (
-  <div ref={ref} role="separator" {...props}>
+const InputOTPSeparator = (props: ComponentPropsWithRef<"div">) => (
+  <div role="separator" {...props}>
     <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
       <path
         d="M6 12h12"
@@ -77,7 +66,6 @@ const InputOTPSeparator = forwardRef<
       />
     </svg>
   </div>
-))
-InputOTPSeparator.displayName = "InputOTPSeparator"
+)
 
 export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/packages/tohuhono/ui/src/components/input.tsx
+++ b/packages/tohuhono/ui/src/components/input.tsx
@@ -1,24 +1,22 @@
-import { InputHTMLAttributes, forwardRef } from "react"
+import { type ComponentPropsWithRef } from "react"
 
 import { cn } from "@tohuhono/utils"
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
-
-const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  },
-)
-Input.displayName = "Input"
+const Input = ({
+  className,
+  type,
+  ...props
+}: ComponentPropsWithRef<"input">) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Input }

--- a/packages/tohuhono/ui/src/components/label.tsx
+++ b/packages/tohuhono/ui/src/components/label.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react"
+import { type ComponentPropsWithRef } from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@tohuhono/utils"
@@ -9,12 +9,11 @@ const labelVariants = cva(
   "text-sm font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 )
 
-const Label = forwardRef<
-  ElementRef<"label">,
-  ComponentPropsWithoutRef<"label"> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <label ref={ref} className={cn(labelVariants(), className)} {...props} />
-))
-Label.displayName = "Label"
+const Label = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"label"> & VariantProps<typeof labelVariants>) => (
+  <label className={cn(labelVariants(), className)} {...props} />
+)
 
 export { Label }

--- a/packages/tohuhono/ui/src/components/navigation-menu.tsx
+++ b/packages/tohuhono/ui/src/components/navigation-menu.tsx
@@ -3,7 +3,6 @@ import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/naviga
 import { cva } from "class-variance-authority"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const NavigationMenu = ({
   className,
@@ -13,7 +12,7 @@ const NavigationMenu = ({
   <NavigationMenuPrimitive.Root
     className={cn(
       "bg-background grid w-full grid-flow-col items-center justify-between p-1",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >
@@ -29,7 +28,7 @@ const NavigationMenuList = ({
   <NavigationMenuPrimitive.List
     className={cn(
       "group flex flex-1 list-none items-center justify-center gap-1",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
@@ -47,11 +46,7 @@ const NavigationMenuTrigger = ({
   ...props
 }: NavigationMenuPrimitive.Trigger.Props) => (
   <NavigationMenuPrimitive.Trigger
-    className={cn(
-      navigationMenuTriggerStyle(),
-      "group",
-      className as ClassNameValue,
-    )}
+    className={cn(navigationMenuTriggerStyle(), "group", className)}
     {...props}
   >
     {children}{" "}
@@ -79,7 +74,7 @@ const NavigationMenuContent = ({
   <NavigationMenuPrimitive.Content
     className={cn(
       "data-[starting-style]:animate-in data-[ending-style]:animate-out data-[starting-style]:fade-in data-[ending-style]:fade-out data-[activation-direction=right]:data-[starting-style]:slide-in-from-right-52 data-[activation-direction=left]:data-[starting-style]:slide-in-from-left-52 data-[activation-direction=right]:data-[ending-style]:slide-out-to-right-52 data-[activation-direction=left]:data-[ending-style]:slide-out-to-left-52 top-0 left-0 w-full md:absolute md:w-auto",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />
@@ -95,7 +90,7 @@ const NavigationMenuViewport = ({
     <NavigationMenuPrimitive.Positioner
       className={cn(
         "absolute top-full left-0 z-50 flex justify-center",
-        className as ClassNameValue,
+        className,
       )}
       side="bottom"
       align="start"
@@ -121,7 +116,7 @@ const NavigationMenuIndicator = ({
   <NavigationMenuPrimitive.Icon
     className={cn(
       "data-[visible]:animate-in data-[hidden]:animate-out data-[hidden]:fade-out data-[visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >

--- a/packages/tohuhono/ui/src/components/popover.tsx
+++ b/packages/tohuhono/ui/src/components/popover.tsx
@@ -4,7 +4,6 @@ import { Children, isValidElement } from "react"
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Popover = PopoverPrimitive.Root
 
@@ -49,7 +48,7 @@ const PopoverContent = ({
       <PopoverPrimitive.Popup
         className={cn(
           "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-none",
-          className as ClassNameValue,
+          className,
         )}
         {...props}
       />

--- a/packages/tohuhono/ui/src/components/radio-group.tsx
+++ b/packages/tohuhono/ui/src/components/radio-group.tsx
@@ -4,14 +4,10 @@ import { Radio as RadioPrimitive } from "@base-ui/react/radio"
 import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const RadioGroup = ({ className, ...props }: RadioGroupPrimitive.Props) => {
   return (
-    <RadioGroupPrimitive
-      className={cn("grid gap-2", className as ClassNameValue)}
-      {...props}
-    />
+    <RadioGroupPrimitive className={cn("grid gap-2", className)} {...props} />
   )
 }
 
@@ -20,7 +16,7 @@ const RadioGroupItem = ({ className, ...props }: RadioPrimitive.Root.Props) => {
     <RadioPrimitive.Root
       className={cn(
         "border-primary text-primary focus-visible:ring-ring aspect-square h-4 w-4 rounded-full border shadow focus:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
-        className as ClassNameValue,
+        className,
       )}
       {...props}
     >

--- a/packages/tohuhono/ui/src/components/scroll-area.tsx
+++ b/packages/tohuhono/ui/src/components/scroll-area.tsx
@@ -3,7 +3,6 @@
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const ScrollArea = ({
   className,
@@ -11,7 +10,7 @@ const ScrollArea = ({
   ...props
 }: ScrollAreaPrimitive.Root.Props) => (
   <ScrollAreaPrimitive.Root
-    className={cn("relative overflow-hidden", className as ClassNameValue)}
+    className={cn("relative overflow-hidden", className)}
     {...props}
   >
     <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
@@ -35,7 +34,7 @@ const ScrollBar = ({
         "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
         "h-2.5 flex-col border-t border-t-transparent p-[1px]",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >

--- a/packages/tohuhono/ui/src/components/select.tsx
+++ b/packages/tohuhono/ui/src/components/select.tsx
@@ -1,10 +1,8 @@
 "use client"
 
-import { ElementRef, forwardRef } from "react"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Select = SelectPrimitive.Root
 
@@ -12,15 +10,15 @@ const SelectGroup = SelectPrimitive.Group
 
 const SelectValue = SelectPrimitive.Value
 
-const SelectTrigger = forwardRef<
-  ElementRef<typeof SelectPrimitive.Trigger>,
-  SelectPrimitive.Trigger.Props
->(({ className, children, ...props }, ref) => (
+const SelectTrigger = ({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props) => (
   <SelectPrimitive.Trigger
-    ref={ref}
     className={cn(
       "border-input ring-offset-background placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >
@@ -42,79 +40,63 @@ const SelectTrigger = forwardRef<
       </svg>
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = "SelectTrigger"
-
-const SelectContent = forwardRef<
-  ElementRef<typeof SelectPrimitive.Popup>,
-  SelectPrimitive.Popup.Props &
-    Pick<
-      SelectPrimitive.Positioner.Props,
-      "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
-    >
->(
-  (
-    {
-      className,
-      children,
-      side = "bottom",
-      sideOffset = 4,
-      align = "center",
-      alignOffset = 0,
-      alignItemWithTrigger = true,
-      ...props
-    },
-    ref,
-  ) => (
-    <SelectPrimitive.Portal>
-      <SelectPrimitive.Positioner
-        side={side}
-        sideOffset={sideOffset}
-        align={align}
-        alignOffset={alignOffset}
-        alignItemWithTrigger={alignItemWithTrigger}
-        className="z-50"
-      >
-        <SelectPrimitive.Popup
-          ref={ref}
-          className={cn(
-            "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
-            className as ClassNameValue,
-          )}
-          {...props}
-        >
-          <SelectPrimitive.List>{children}</SelectPrimitive.List>
-        </SelectPrimitive.Popup>
-      </SelectPrimitive.Positioner>
-    </SelectPrimitive.Portal>
-  ),
 )
-SelectContent.displayName = "SelectContent"
 
-const SelectLabel = forwardRef<
-  ElementRef<typeof SelectPrimitive.GroupLabel>,
-  SelectPrimitive.GroupLabel.Props
->(({ className, ...props }, ref) => (
+const SelectContent = ({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Positioner
+      side={side}
+      sideOffset={sideOffset}
+      align={align}
+      alignOffset={alignOffset}
+      alignItemWithTrigger={alignItemWithTrigger}
+      className="z-50"
+    >
+      <SelectPrimitive.Popup
+        className={cn(
+          "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          className,
+        )}
+        {...props}
+      >
+        <SelectPrimitive.List>{children}</SelectPrimitive.List>
+      </SelectPrimitive.Popup>
+    </SelectPrimitive.Positioner>
+  </SelectPrimitive.Portal>
+)
+
+const SelectLabel = ({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) => (
   <SelectPrimitive.GroupLabel
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
-      className as ClassNameValue,
-    )}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
   />
-))
-SelectLabel.displayName = "SelectLabel"
+)
 
-const SelectItem = forwardRef<
-  ElementRef<typeof SelectPrimitive.Item>,
-  SelectPrimitive.Item.Props
->(({ className, children, ...props }, ref) => (
+const SelectItem = ({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) => (
   <SelectPrimitive.Item
-    ref={ref}
     className={cn(
       "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >
@@ -134,20 +116,17 @@ const SelectItem = forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = "SelectItem"
+)
 
-const SelectSeparator = forwardRef<
-  ElementRef<typeof SelectPrimitive.Separator>,
-  SelectPrimitive.Separator.Props
->(({ className, ...props }, ref) => (
+const SelectSeparator = ({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) => (
   <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("bg-muted -mx-1 my-1 h-px", className as ClassNameValue)}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = "SelectSeparator"
+)
 
 export {
   Select,

--- a/packages/tohuhono/ui/src/components/separator.tsx
+++ b/packages/tohuhono/ui/src/components/separator.tsx
@@ -3,7 +3,6 @@
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Separator = ({
   className,
@@ -14,7 +13,7 @@ const Separator = ({
     orientation={orientation}
     className={cn(
       "bg-border shrink-0 data-horizontal:h-[1px] data-horizontal:w-full data-vertical:h-full data-vertical:w-[1px]",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   />

--- a/packages/tohuhono/ui/src/components/switch.tsx
+++ b/packages/tohuhono/ui/src/components/switch.tsx
@@ -3,13 +3,12 @@
 import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const Switch = ({ className, ...props }: SwitchPrimitive.Root.Props) => (
   <SwitchPrimitive.Root
     className={cn(
       "peer focus-visible:ring-ring focus-visible:ring-offset-background data-[checked]:bg-primary data-[unchecked]:bg-input inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-      className as ClassNameValue,
+      className,
     )}
     {...props}
   >

--- a/packages/tohuhono/ui/src/components/table.tsx
+++ b/packages/tohuhono/ui/src/components/table.tsx
@@ -1,116 +1,79 @@
-import {
-  HTMLAttributes,
-  TdHTMLAttributes,
-  ThHTMLAttributes,
-  forwardRef,
-} from "react"
+import { type ComponentPropsWithRef } from "react"
 
 import { cn } from "@tohuhono/utils"
 
-const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table
-        ref={ref}
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
-    </div>
-  ),
+const Table = ({ className, ...props }: ComponentPropsWithRef<"table">) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
 )
-Table.displayName = "Table"
 
-const TableHeader = forwardRef<
-  HTMLTableSectionElement,
-  HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+const TableHeader = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"thead">) => (
+  <thead className={cn("[&_tr]:border-b", className)} {...props} />
+)
 
-const TableBody = forwardRef<
-  HTMLTableSectionElement,
-  HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+const TableBody = ({ className, ...props }: ComponentPropsWithRef<"tbody">) => (
+  <tbody className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+)
 
-const TableFooter = forwardRef<
-  HTMLTableSectionElement,
-  HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
+const TableFooter = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"tfoot">) => (
   <tfoot
-    ref={ref}
     className={cn(
       "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
       className,
     )}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+)
 
-const TableRow = forwardRef<
-  HTMLTableRowElement,
-  HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
+const TableRow = ({ className, ...props }: ComponentPropsWithRef<"tr">) => (
   <tr
-    ref={ref}
     className={cn(
       "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
       className,
     )}
     {...props}
   />
-))
-TableRow.displayName = "TableRow"
+)
 
-const TableHead = forwardRef<
-  HTMLTableCellElement,
-  ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+const TableHead = ({ className, ...props }: ComponentPropsWithRef<"th">) => (
   <th
-    ref={ref}
     className={cn(
       "text-muted-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className,
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+)
 
-const TableCell = forwardRef<
-  HTMLTableCellElement,
-  TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+const TableCell = ({ className, ...props }: ComponentPropsWithRef<"td">) => (
   <td
-    ref={ref}
     className={cn(
       "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className,
     )}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+)
 
-const TableCaption = forwardRef<
-  HTMLTableCaptionElement,
-  HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
+const TableCaption = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"caption">) => (
   <caption
-    ref={ref}
     className={cn("text-muted-foreground mt-4 text-sm", className)}
     {...props}
   />
-))
-TableCaption.displayName = "TableCaption"
+)
 
 export {
   Table,

--- a/packages/tohuhono/ui/src/components/textarea.tsx
+++ b/packages/tohuhono/ui/src/components/textarea.tsx
@@ -1,23 +1,20 @@
-import { TextareaHTMLAttributes, forwardRef } from "react"
+import { type ComponentPropsWithRef } from "react"
 
 import { cn } from "@tohuhono/utils"
 
-export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
-
-const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  },
-)
-Textarea.displayName = "Textarea"
+const Textarea = ({
+  className,
+  ...props
+}: ComponentPropsWithRef<"textarea">) => {
+  return (
+    <textarea
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Textarea }

--- a/packages/tohuhono/ui/src/components/toaster.tsx
+++ b/packages/tohuhono/ui/src/components/toaster.tsx
@@ -22,13 +22,26 @@ const toastVariants = cva(
   },
 )
 
+function getToastData(value: unknown): ToastData {
+  if (!value || typeof value !== "object") {
+    return {}
+  }
+
+  const variant = "variant" in value ? value.variant : undefined
+  if (variant === "default" || variant === "destructive") {
+    return { variant }
+  }
+
+  return {}
+}
+
 function ToastItems() {
   const { toasts } = ToastPrimitive.useToastManager()
 
   return (
     <>
       {toasts.map((toast) => {
-        const data = (toast.data ?? {}) as ToastData
+        const data = getToastData(toast.data)
 
         return (
           <ToastPrimitive.Root

--- a/packages/tohuhono/ui/src/components/tooltip.tsx
+++ b/packages/tohuhono/ui/src/components/tooltip.tsx
@@ -4,7 +4,6 @@ import { Children, isValidElement } from "react"
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 
 import { cn } from "@tohuhono/utils"
-import type { ClassNameValue } from "tailwind-merge"
 
 const TooltipProvider = ({
   delay,
@@ -59,7 +58,7 @@ const TooltipContent = ({
       <TooltipPrimitive.Popup
         className={cn(
           "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs",
-          className as ClassNameValue,
+          className,
         )}
         {...props}
       />


### PR DESCRIPTION
## Changeset Summary

### @tohuhono/ui
Adopt React 19 ref-as-prop patterns across UI components by removing `forwardRef` wrappers.

- Replaced `forwardRef` usage in component wrappers with plain function components.
- Updated component prop types to `ComponentPropsWithRef<...>` where refs should be accepted.
- Kept runtime behavior and component structure intact while simplifying the public API surface.

### @tohuhono/ui + @tohuhono/utils
Remove UI type assertions for Base UI class names and keep type-safety intact.

- Replaced `as` assertions in `@tohuhono/ui` components with structural typing and runtime guards.
- Updated button/form/toaster internals to avoid unsafe assertions while preserving behavior.
- Enhanced `cn` in `@tohuhono/utils` to support state-based className functions used by Base UI primitives.

### @tohuhono/dev
Promote `tohuhono/no-type-assertion-except-object-keys` from warning to error in the shared ESLint config.
