### PR TITLE
chore: expand tsconfig coverage

### DIFF
--- a/.changeset/config-ts-coverage-drizzle-dialect.md
+++ b/.changeset/config-ts-coverage-drizzle-dialect.md
@@ -1,0 +1,13 @@
+---
+"@oberoncms/plugin-development": patch
+"@oberoncms/plugin-pgsql": patch
+"@oberoncms/plugin-turso": patch
+"@oberoncms/plugin-vercel-postgres": patch
+"@oberoncms/sqlite": patch
+---
+
+Include root `*.config.ts` files in package TypeScript configs so config files
+are typechecked.
+
+Also update drizzle config typing to the current `drizzle-kit` `dialect` field
+to keep checks passing.

--- a/.changeset/create-oberon-app-plugin-tsconfig.md
+++ b/.changeset/create-oberon-app-plugin-tsconfig.md
@@ -1,0 +1,9 @@
+---
+"create-oberon-app": patch
+---
+
+Include `plugins/**/*.ts` in `create-oberon-app` TypeScript config so plugin
+templates are typechecked.
+
+Also narrow unknown caught errors in the Sendgrid template to satisfy strict
+typechecking.

--- a/packages/create-oberon-app/plugins/send/sendgrid.ts
+++ b/packages/create-oberon-app/plugins/send/sendgrid.ts
@@ -1,6 +1,6 @@
 import "server-cli-only"
 
-import sgMail from "@sendgrid/mail"
+import { setApiKey, send, ResponseError } from "@sendgrid/mail"
 import {
   USE_DEVELOPMENT_SEND_PLUGIN,
   type OberonPlugin,
@@ -38,14 +38,14 @@ export const plugin: OberonPlugin = () => ({
         text: `Sign in with code\n\n${token}\n\n ${url} \n\n`,
       }
 
-      sgMail.setApiKey(SENDGRID_API_KEY)
+      setApiKey(SENDGRID_API_KEY)
 
       try {
-        await sgMail.send(msg)
+        await send(msg)
       } catch (error) {
         console.error(error)
 
-        if (error.response) {
+        if (error instanceof ResponseError) {
           console.error(error.response.body)
         }
       }

--- a/packages/create-oberon-app/tsconfig.json
+++ b/packages/create-oberon-app/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "plugins/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/packages/oberoncms/sqlite/drizzle.config.ts
+++ b/packages/oberoncms/sqlite/drizzle.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "drizzle-kit"
 export default {
   schema: "./src/db/schema/index.ts",
   out: "./src/db/migrations",
-  driver: "libsql",
+  dialect: "sqlite",
 } satisfies Config

--- a/packages/oberoncms/sqlite/tsconfig.json
+++ b/packages/oberoncms/sqlite/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": ".",
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "*.config.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/packages/plugins/development/drizzle.config.ts
+++ b/packages/plugins/development/drizzle.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "drizzle-kit"
 export default {
   schema: "./src/db/schema/index.ts",
   out: "./src/db/migrations",
-  driver: "libsql",
+  dialect: "sqlite",
 } satisfies Config

--- a/packages/plugins/development/tsconfig.json
+++ b/packages/plugins/development/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": ".",
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "*.config.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/packages/plugins/pgsql/drizzle.config.ts
+++ b/packages/plugins/pgsql/drizzle.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "drizzle-kit"
 export default {
   schema: "./src/db/schema/index.ts",
   out: "./src/db/migrations",
-  driver: "pg",
+  dialect: "postgresql",
 } satisfies Config

--- a/packages/plugins/pgsql/tsconfig.json
+++ b/packages/plugins/pgsql/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": ".",
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "*.config.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/packages/plugins/turso/drizzle.config.ts
+++ b/packages/plugins/turso/drizzle.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "drizzle-kit"
 export default {
   schema: "./src/db/schema/index.ts",
   out: "./src/db/migrations",
-  driver: "libsql",
+  dialect: "sqlite",
 } satisfies Config

--- a/packages/plugins/turso/tsconfig.json
+++ b/packages/plugins/turso/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": ".",
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "*.config.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/packages/plugins/vercel-postgres/drizzle.config.ts
+++ b/packages/plugins/vercel-postgres/drizzle.config.ts
@@ -3,5 +3,5 @@ import type { Config } from "drizzle-kit"
 export default {
   schema: "./src/db/schema/index.ts",
   out: "./src/db/migrations",
-  driver: "pg",
+  dialect: "postgresql",
 } satisfies Config

--- a/packages/plugins/vercel-postgres/tsconfig.json
+++ b/packages/plugins/vercel-postgres/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "@tohuhono/typescript-config",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": ".",
     "jsx": "react-jsx"
   },
-  "include": ["src", "scripts"],
+  "include": ["src", "scripts", "*.config.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.spec.tsx"]
 }


### PR DESCRIPTION
## Summary
- include root `*.config.ts` in affected plugin/adapter package tsconfigs
- include `plugins/**/*.ts` in create-oberon-app tsconfig
- align drizzle config typing with current drizzle-kit dialect config
- keep create-oberon-app sendgrid template type-safe under strict catch typing

## Validation
- pnpm check
- pnpm build