### PR TITLE
chore: migrate publishing auth to oidc

### DIFF
--- a/.changeset/oidc-trusted-publishing.md
+++ b/.changeset/oidc-trusted-publishing.md
@@ -1,0 +1,19 @@
+---
+"create-oberon-app": patch
+"@oberoncms/core": patch
+"@oberoncms/sqlite": patch
+"@oberoncms/plugin-development": patch
+"@oberoncms/plugin-flydrive": patch
+"@oberoncms/plugin-pgsql": patch
+"@oberoncms/plugin-turso": patch
+"@oberoncms/plugin-uploadthing": patch
+"@tohuhono/puck-blocks": patch
+"@tohuhono/ui": patch
+"@tohuhono/utils": patch
+---
+
+Migrate package publishing to npm trusted publishing with GitHub OIDC.
+
+- update release workflow permissions for OIDC token exchange
+- remove static `NPM_TOKEN` usage from publish job
+- enable npm provenance in CI and package publish metadata

--- a/.changeset/pnpm-exec-automation.md
+++ b/.changeset/pnpm-exec-automation.md
@@ -1,0 +1,8 @@
+---
+"create-oberon-app": patch
+---
+
+Use pnpm-native command execution in repository automation.
+
+- replace `npx turbo` with `pnpm exec turbo` in changed-package script
+- replace workflow `npx vercel` usage with pnpm-based execution

--- a/.github/workflows/call-promote.yml
+++ b/.github/workflows/call-promote.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24.x"
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
       - name: Alias build to production
         run: |
-          npx vercel alias ${{ inputs.staging_url }} ${{ inputs.production_url }} --token=${{ secrets.VERCEL_API_TOKEN }} --scope ${{ vars.VERCEL_SCOPE }}
+          pnpm dlx vercel alias ${{ inputs.staging_url }} ${{ inputs.production_url }} --token=${{ secrets.VERCEL_API_TOKEN }} --scope ${{ vars.VERCEL_SCOPE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
-  ## for pnpm provenance
-  # id-token: write
+  id-token: write
 
 jobs:
   release:
@@ -51,6 +50,4 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          ## npm provenance
-          # NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/create-oberon-app/package.json
+++ b/packages/create-oberon-app/package.json
@@ -29,6 +29,9 @@
     "generate:recipes": "node scripts/generate.mjs",
     "prepublishOnly": "pnpm generate:recipes"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "commander": "^14.0.3",

--- a/packages/oberoncms/core/package.json
+++ b/packages/oberoncms/core/package.json
@@ -44,6 +44,10 @@
     "lint": "eslint .",
     "tsc": "tsc --pretty"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@auth/core": "^0.37.4",
     "@hookform/resolvers": "^5.2.2",

--- a/packages/oberoncms/sqlite/package.json
+++ b/packages/oberoncms/sqlite/package.json
@@ -47,6 +47,10 @@
     "wait": "wait-on ./dist/version && echo done",
     "wait:clean": "rimraf ./dist/version"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@libsql/client": "^0.17.0",
     "@libsql/core": "^0.17.0",

--- a/packages/plugins/development/package.json
+++ b/packages/plugins/development/package.json
@@ -39,6 +39,10 @@
     "wait": "wait-on ./dist/version && echo done",
     "wait:clean": "rimraf ./dist/version"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@libsql/client": "^0.17.0",
     "@libsql/core": "^0.17.0",

--- a/packages/plugins/flydrive/package.json
+++ b/packages/plugins/flydrive/package.json
@@ -50,6 +50,10 @@
     "lint": "eslint .",
     "tsc": "tsc --pretty"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@oberoncms/core": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/plugins/pgsql/package.json
+++ b/packages/plugins/pgsql/package.json
@@ -53,6 +53,10 @@
     "wait": "wait-on ./dist/version && echo done",
     "wait:clean": "rimraf ./dist/version"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",
     "@oberoncms/core": "workspace:*",

--- a/packages/plugins/turso/package.json
+++ b/packages/plugins/turso/package.json
@@ -40,6 +40,10 @@
     "wait": "wait-on ./dist/version && echo done",
     "wait:clean": "rimraf ./dist/version"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@libsql/client": "^0.17.0",
     "@oberoncms/core": "workspace:*",

--- a/packages/plugins/uploadthing/package.json
+++ b/packages/plugins/uploadthing/package.json
@@ -48,6 +48,10 @@
     "lint": "eslint .",
     "tsc": "tsc --pretty"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@oberoncms/core": "workspace:*",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/tohuhono/puck-blocks/package.json
+++ b/packages/tohuhono/puck-blocks/package.json
@@ -43,6 +43,10 @@
     "lint": "eslint .",
     "tsc": "tsc --pretty"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@oberoncms/core": "workspace:*",
     "@tohuhono/ui": "workspace:*",

--- a/packages/tohuhono/ui/package.json
+++ b/packages/tohuhono/ui/package.json
@@ -60,6 +60,10 @@
     "./tooltip": "./dist/tooltip.js",
     "./tailwind.css": "./tailwind.css"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
     "@config/eslint": "workspace:*",

--- a/packages/tohuhono/utils/package.json
+++ b/packages/tohuhono/utils/package.json
@@ -30,6 +30,10 @@
     "README*",
     "LICENSE*"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "dependencies": {
     "tailwind-merge": "^3.4.1"
   },

--- a/scripts/changed.sh
+++ b/scripts/changed.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-npx -y turbo build --dry-run=json --filter=...[$1]  --global-deps=.github/* | node -p 'JSON.parse(fs.readFileSync(0)).packages'
+pnpm exec turbo build --dry-run=json --filter=...[$1]  --global-deps=.github/* | node -p 'JSON.parse(fs.readFileSync(0)).packages'


### PR DESCRIPTION
This PR migrates publishing auth to npm trusted publishing via GitHub OIDC and switches remaining automation npx usage to pnpm-based execution.