### PR TITLE
fix: align package repository metadata for provenance

### DIFF
--- a/.changeset/provenance-repository-url-normalisation.md
+++ b/.changeset/provenance-repository-url-normalisation.md
@@ -1,0 +1,16 @@
+---
+"create-oberon-app": patch
+"@oberoncms/core": patch
+"@oberoncms/sqlite": patch
+"@oberoncms/plugin-development": patch
+"@oberoncms/plugin-flydrive": patch
+"@oberoncms/plugin-pgsql": patch
+"@oberoncms/plugin-turso": patch
+"@oberoncms/plugin-uploadthing": patch
+"@tohuhono/puck-blocks": patch
+"@tohuhono/ui": patch
+"@tohuhono/utils": patch
+---
+
+Normalize package `repository.url` metadata to the canonical GitHub repository
+URL used in npm provenance validation.

--- a/packages/create-oberon-app/package.json
+++ b/packages/create-oberon-app/package.json
@@ -2,7 +2,11 @@
   "name": "create-oberon-app",
   "version": "0.10.0",
   "author": "Tohuhono ltd",
-  "repository": "tohuhono/oberon",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Tohuhono/Oberon",
+    "directory": "packages/create-oberon-app"
+  },
   "bugs": "https://github.com/tohuhono/oberon",
   "homepage": "https://tohuhono.com/oberon",
   "license": "MIT",

--- a/packages/oberoncms/core/package.json
+++ b/packages/oberoncms/core/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/oberoncms/core"
   },
   "type": "module",

--- a/packages/oberoncms/sqlite/package.json
+++ b/packages/oberoncms/sqlite/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/oberoncms/sqlite"
   },
   "type": "module",

--- a/packages/plugins/development/package.json
+++ b/packages/plugins/development/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/plugins/development"
   },
   "type": "module",

--- a/packages/plugins/flydrive/package.json
+++ b/packages/plugins/flydrive/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/plugins/flydrive"
   },
   "type": "module",

--- a/packages/plugins/pgsql/package.json
+++ b/packages/plugins/pgsql/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/plugins/pgsql"
   },
   "type": "module",

--- a/packages/plugins/turso/package.json
+++ b/packages/plugins/turso/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/plugins/turso"
   },
   "type": "module",

--- a/packages/plugins/uploadthing/package.json
+++ b/packages/plugins/uploadthing/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/plugins/uploadthing"
   },
   "type": "module",

--- a/packages/tohuhono/puck-blocks/package.json
+++ b/packages/tohuhono/puck-blocks/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/tohuhono/puck-blocks"
   },
   "type": "module",

--- a/packages/tohuhono/ui/package.json
+++ b/packages/tohuhono/ui/package.json
@@ -6,7 +6,7 @@
   "description": "A UI library used by @tohuhono and @oberoncms packages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/tohuhono/ui"
   },
   "type": "module",

--- a/packages/tohuhono/utils/package.json
+++ b/packages/tohuhono/utils/package.json
@@ -6,7 +6,7 @@
   "description": "A collection of utility functions used by @tohuhono and @oberoncms packages",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tohuhono/Oberon.git",
+    "url": "https://github.com/Tohuhono/Oberon",
     "directory": "packages/tohuhono/utils"
   },
   "type": "module",


### PR DESCRIPTION
Align package repository metadata with canonical GitHub URL for npm provenance verification.

Changeset included: .changeset/provenance-repository-url-normalisation.md