### PR TITLE
fix: remove infinite loop in flydrive getImageSize

### DIFF
--- a/.changeset/fix-flydrive-infinite-loop.md
+++ b/.changeset/fix-flydrive-infinite-loop.md
@@ -1,0 +1,7 @@
+---
+"@oberoncms/plugin-flydrive": patch
+---
+
+Fix infinite loop in getImageSize() that could hang the application when image
+size cannot be determined. The function now tries once and falls back to default
+size on error, instead of looping forever on a static buffer.

--- a/agents/plans/fix-action-plan.md
+++ b/agents/plans/fix-action-plan.md
@@ -14,7 +14,7 @@ For each issue:
 
 ## Phase 1: P0 - Production Blockers 🔴
 
-- [ ] **1.1** Fix infinite loop -
+- [x] **1.1** Fix infinite loop -
       [Review #1](./critical-code-review.md#1-infinite-loop-can-hang-application)
       `packages/plugins/flydrive/src/internal/get-image-size.ts`
 
@@ -107,4 +107,4 @@ For each issue:
 - [ ] **3.8** Add input validation -
       [Review](./critical-code-review.md#input-validation-gaps)
 
-**Progress**: 0/24 complete
+**Progress**: 1/24 complete

--- a/packages/plugins/flydrive/src/internal/get-image-size.ts
+++ b/packages/plugins/flydrive/src/internal/get-image-size.ts
@@ -6,17 +6,13 @@ export async function getImageSize(
   image: Buffer,
   defaultSize: ImageSize = { width: 100, height: 100 },
 ): Promise<ImageSize> {
-  while (true) {
-    try {
-      // This throws if it cannot determine the size
-      const { width, height } = imageSize(image)
-      if (width && height) {
-        return { width, height }
-      }
-      // If the width or height are (probably incorrectly) zero, return the default
-      return defaultSize
-    } catch (error) {
-      // Cannot determine the size yet
+  try {
+    const { width, height } = imageSize(image)
+    if (width && height) {
+      return { width, height }
     }
+    return defaultSize
+  } catch (error) {
+    return defaultSize
   }
 }


### PR DESCRIPTION
## Summary

Fixes critical production blocker #1.1: Infinite loop in `getImageSize()` that could hang the application indefinitely when image size cannot be determined.

## Changes

- Removed `while(true)` loop from `packages/plugins/flydrive/src/internal/get-image-size.ts`
- Function now tries once to determine image size and falls back to default on error
- Updated fix action plan progress (1/24 complete)

## Why

The original implementation had no exit condition for a static buffer. If `imageSize(buffer)` threw an error, it would loop forever, blocking the entire POST request handler at `/cms/api/flydrive`.

Since the buffer is static (not streaming like the uploadthing version), `imageSize()` behavior is deterministic—if it fails once, it will always fail on the same buffer.

## Test plan

- [x] `pnpm check` passes (lint + typecheck)
- [x] `pnpm build` succeeds
- [x] Changeset created

🤖 Generated with [Claude Code](https://claude.com/claude-code)