### PR TITLE
fix: add memory limit to uploadthing stream processing

### DIFF
--- a/.changeset/fix-uploadthing-memory-limit.md
+++ b/.changeset/fix-uploadthing-memory-limit.md
@@ -1,0 +1,8 @@
+---
+"@oberoncms/plugin-uploadthing": patch
+---
+
+Add memory limit (128KB) to stream processing in getImageSize() to prevent
+unbounded memory consumption. Large image uploads now abort gracefully after
+reading sufficient data for header detection, preventing OOM crashes while
+maintaining backward compatibility.

--- a/agents/plans/fix-action-plan.md
+++ b/agents/plans/fix-action-plan.md
@@ -7,7 +7,9 @@ Fix the next single issue; mark complete after PR merged.
 For each issue:
 
 - Follow plan mode workflow as a senior developer
-- Verify analysis against recent documentation and monorepo context
+- Verify that the analysis is correct
+- Review recent github issues, release notes and documentation for imported
+  packages where relevant
 - Ensure alignment with architecture, codestyle, and conventions
 
 ---
@@ -18,7 +20,7 @@ For each issue:
       [Review #1](./critical-code-review.md#1-infinite-loop-can-hang-application)
       `packages/plugins/flydrive/src/internal/get-image-size.ts`
 
-- [ ] **1.2** Add memory limits to stream -
+- [x] **1.2** Add memory limits to stream -
       [Review #2](./critical-code-review.md#2-unbounded-memory-consumption-in-stream-processing)
       `packages/plugins/uploadthing/src/uploadthing/get-image-size.ts`
 
@@ -107,4 +109,4 @@ For each issue:
 - [ ] **3.8** Add input validation -
       [Review](./critical-code-review.md#input-validation-gaps)
 
-**Progress**: 1/24 complete
+**Progress**: 2/24 complete

--- a/packages/plugins/uploadthing/src/uploadthing/get-image-size.ts
+++ b/packages/plugins/uploadthing/src/uploadthing/get-image-size.ts
@@ -7,6 +7,8 @@ export async function getImageSize(
   url: string,
   defaultSize: ImageSize = { width: 100, height: 100 },
 ): Promise<ImageSize> {
+  const MAX_HEADER_BYTES = 128 * 1024 // 128KB
+  let totalBytes = 0
   const chunks: Uint8Array[] = []
   const response = await fetch(url)
   if (!response.body) {
@@ -18,6 +20,11 @@ export async function getImageSize(
     if (done) {
       return defaultSize
     }
+    if (totalBytes + value.length > MAX_HEADER_BYTES) {
+      reader.cancel()
+      return defaultSize
+    }
+    totalBytes += value.length
     chunks.push(value)
     try {
       // This throws if it cannot determine the size


### PR DESCRIPTION
## Summary

Fixes issue 1.2 from critical code review: adds 128KB memory limit to stream processing in uploadthing's `getImageSize()` to prevent unbounded memory consumption and OOM crashes.

## Changes

- Add `MAX_HEADER_BYTES` constant (128KB) to limit stream buffer size
- Track cumulative bytes as chunks accumulate
- Abort stream early and return default size when limit exceeded
- Call `reader.cancel()` to free resources

## Rationale

- Image headers are tiny (PNG: 21B, JPEG: 160B, GIF: 13B)
- 128KB is 32x+ larger than needed, based on image-size-stream default
- Well under existing 4MB maxFileSize upload limit
- Maintains fail-fast pattern from issue 1.1 fix

## Test plan

- [x] `pnpm check` - lint and typecheck passed
- [x] `pnpm build` - all packages built successfully
- [x] Changeset created

🤖 Generated with [Claude Code](https://claude.com/claude-code)