### PR TITLE
docs: reorganize validation guidelines and track issue 1.4 deferral

### DIFF
--- a/agents/CODESTYLE.md
+++ b/agents/CODESTYLE.md
@@ -31,3 +31,13 @@
 ## Next.js
 
 - Next.js App Router conventions apply; keep server actions with `"use server"`
+
+## Validation
+
+Shell-Validation Pattern: Zod at the gates, Types in the streets.
+
+- Validate with Zod; infer types;
+- Parse, Don't Just Validate.
+- Fail Early and Loudly.
+- Avoid runtime validation checks in internal business logic to maximize
+  performance and minimize code clutter; favour improving static checking;

--- a/agents/CONVENTIONS.md
+++ b/agents/CONVENTIONS.md
@@ -10,16 +10,6 @@
   `Image` from `@oberoncms/plugin-uploadthing`).
 - Core adapter conventions live in `packages/oberoncms/core/AGENTS.md`.
 
-## Validation
-
-Shell-Validation Pattern: Zod at the gates, Types in the streets.
-
-- Validate with Zod; infer types;
-- Parse, Don't Just Validate.
-- Fail Early and Loudly.
-- Avoid runtime validation checks in internal business logic to maximize
-  performance and minimize code clutter; favour improving static checking;
-
 ## Integrations
 
 - Email sending: `apps/playground/oberon/send.ts` uses Resend (`RESEND_SECRET`,

--- a/agents/plans/fix-action-plan.md
+++ b/agents/plans/fix-action-plan.md
@@ -28,9 +28,10 @@ For each issue:
       [Review #3](./critical-code-review.md#3-unsafe-permission-dictionary-access)
       `packages/oberoncms/core/src/adapter/init-plugins.ts:41-42`
 
-- [ ] **1.4** Validate user role at runtime -
+- [x] **1.4** ~~Validate user role at runtime~~ - **Deferred to 2.1**
       [Review #4](./critical-code-review.md#4-runtime-crash-on-invalid-user-role)
-      `packages/oberoncms/core/src/adapter/init-plugins.ts:35-43`
+      Per Shell-Validation pattern: validate at database read layer (2.1) rather
+      than runtime checks
 
 - [ ] **1.5** Fix silent data loss in deletions -
       [Review #5](./critical-code-review.md#5-silent-data-loss-in-file-deletion)
@@ -61,6 +62,7 @@ For each issue:
       [Review #4](./critical-code-review.md#4-runtime-crash-on-invalid-user-role)
       Validate users, pages, images, site data when reading from database.
       Ensures data integrity at the gate per Shell-Validation pattern.
+      **Includes deferred issue 1.4** (user role validation).
       `packages/plugins/pgsql/src/db/database-adapter.ts`
       `packages/oberoncms/sqlite/src/db/database-adapter.ts`
 
@@ -116,4 +118,4 @@ For each issue:
 - [ ] **3.8** Add input validation -
       [Review](./critical-code-review.md#input-validation-gaps)
 
-**Progress**: 3/25 complete
+**Progress**: 4/25 complete (1 deferred to 2.1)


### PR DESCRIPTION
## Summary
- Move Shell-Validation pattern from CONVENTIONS.md to CODESTYLE.md for better organization
- Mark issue 1.4 (validate user role at runtime) as deferred to issue 2.1 (database validation)
- Add cross-reference in issue 2.1 noting it includes the deferred issue 1.4

## Context
Following the Shell-Validation pattern principle: "Zod at the gates, Types in the streets" - validate data at database read layer rather than adding runtime checks in business logic.

## Test plan
- [x] Documentation changes only
- [x] Issue tracking updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)