### PR TITLE
Replace Puck DropZone blocks with slots and infer Oberon field props

### DIFF
--- a/.changeset/fair-lions-wash.md
+++ b/.changeset/fair-lions-wash.md
@@ -1,0 +1,6 @@
+---
+"@tohuhono/puck-blocks": patch
+---
+
+Replace deprecated Puck DropZone usage in shared Container and Prose blocks with
+slot fields.

--- a/.changeset/ten-mangos-nail.md
+++ b/.changeset/ten-mangos-nail.md
@@ -1,0 +1,7 @@
+---
+"@oberoncms/core": patch
+"@tohuhono/puck-blocks": patch
+---
+
+Infer Oberon component render props from field definitions and adopt the helper
+in shared puck blocks.

--- a/packages/oberoncms/core/src/lib/dtd.test.ts
+++ b/packages/oberoncms/core/src/lib/dtd.test.ts
@@ -1,0 +1,89 @@
+import { createElement } from "react"
+import type { ReactNode } from "react"
+import { describe, expectTypeOf, it } from "@dev/vitest"
+import type { SlotComponent } from "@puckeditor/core"
+import { defineOberonComponent } from "./dtd"
+
+describe(
+  "defineOberonComponent",
+  { tags: ["ai", "feature-component-typing"] },
+  () => {
+    it("infers text and slot props from fields while preserving Puck props", () => {
+      const component = defineOberonComponent({
+        fields: {
+          className: {
+            type: "text",
+          },
+          content: {
+            type: "slot",
+          },
+        },
+        render: ({ className, content: Content, id, puck, editMode }) => {
+          expectTypeOf(className).toEqualTypeOf<string | undefined>()
+          expectTypeOf(Content).toEqualTypeOf<SlotComponent>()
+          expectTypeOf(id).toEqualTypeOf<string>()
+          expectTypeOf(puck).toBeObject()
+          expectTypeOf(editMode).toEqualTypeOf<boolean | undefined>()
+
+          return createElement(
+            "div",
+            {
+              className,
+              "data-component-id": id,
+              "data-edit-mode": editMode,
+            },
+            createElement(Content),
+            String(Boolean(puck.isEditing)),
+          )
+        },
+      })
+
+      type RenderProps = Parameters<typeof component.render>[0]
+
+      expectTypeOf<RenderProps["className"]>().toEqualTypeOf<
+        string | undefined
+      >()
+      expectTypeOf<RenderProps["content"]>().toEqualTypeOf<SlotComponent>()
+    })
+
+    it("infers rich text values and content-editable textareas as ReactNode", () => {
+      defineOberonComponent({
+        fields: {
+          body: {
+            type: "richtext",
+          },
+          text: {
+            type: "textarea",
+            contentEditable: true,
+          },
+        },
+        render: ({ body, text }) => {
+          expectTypeOf(body).toEqualTypeOf<ReactNode | undefined>()
+          expectTypeOf(text).toEqualTypeOf<ReactNode | undefined>()
+
+          return createElement("div", undefined, body, text)
+        },
+      })
+    })
+
+    it("lets render annotations override ambiguous field inference", () => {
+      type ImageValue = { url: string } | null
+
+      defineOberonComponent({
+        fields: {
+          image: {
+            type: "custom",
+            render: () => createElement("div"),
+          },
+        },
+        render: ({ image }: { image?: ImageValue }) => {
+          expectTypeOf(image).toEqualTypeOf<ImageValue | undefined>()
+
+          return image
+            ? createElement("img", { alt: "", src: image.url })
+            : createElement("div")
+        },
+      })
+    })
+  },
+)

--- a/packages/oberoncms/core/src/lib/dtd.ts
+++ b/packages/oberoncms/core/src/lib/dtd.ts
@@ -1,11 +1,13 @@
 import { z } from "zod"
 import { Route } from "next"
+import type { ReactNode } from "react"
 import type {
   ComponentConfig,
   Config,
   Data,
   DefaultComponentProps,
   DefaultComponents,
+  SlotComponent,
 } from "@puckeditor/core"
 import type { AdapterUser, Adapter as AuthAdapter } from "@auth/core/adapters"
 import type { StreamResponseChunk } from "@tohuhono/utils"
@@ -41,6 +43,64 @@ export type OberonComponent<
 > = ComponentConfig<{
   props: Props
 }>
+
+type OberonFieldMap = Record<string, { type: string }>
+
+type InferOberonFieldProp<FieldConfig> = FieldConfig extends { type: "slot" }
+  ? SlotComponent
+  : FieldConfig extends { type: "richtext" }
+    ? ReactNode
+    : FieldConfig extends { type: "textarea"; contentEditable: true }
+      ? ReactNode
+      : FieldConfig extends { type: "text" | "textarea" }
+        ? string
+        : FieldConfig extends { type: "number" }
+          ? number
+          : unknown
+
+type InferOberonRequiredFieldKeys<FieldMap extends OberonFieldMap> = {
+  [Key in keyof FieldMap]: FieldMap[Key] extends { type: "slot" } ? Key : never
+}[keyof FieldMap]
+
+type InferOberonOptionalFieldKeys<FieldMap extends OberonFieldMap> = Exclude<
+  keyof FieldMap,
+  InferOberonRequiredFieldKeys<FieldMap>
+>
+
+type InferOberonFieldProps<FieldMap extends OberonFieldMap> = {
+  [Key in InferOberonRequiredFieldKeys<FieldMap>]: InferOberonFieldProp<
+    FieldMap[Key]
+  >
+} & {
+  [Key in InferOberonOptionalFieldKeys<FieldMap>]?: InferOberonFieldProp<
+    FieldMap[Key]
+  >
+}
+
+type DefineOberonComponentConfig<
+  Props extends DefaultComponentProps,
+  FieldMap extends OberonFieldMap,
+> = Omit<OberonComponent<Props>, "fields"> & {
+  fields?: FieldMap & NonNullable<OberonComponent<Props>["fields"]>
+}
+
+export function defineOberonComponent<const FieldMap extends OberonFieldMap>(
+  config: DefineOberonComponentConfig<
+    InferOberonFieldProps<FieldMap>,
+    FieldMap
+  >,
+): OberonComponent<InferOberonFieldProps<FieldMap>>
+
+export function defineOberonComponent<
+  Props extends DefaultComponentProps,
+  const FieldMap extends OberonFieldMap = {},
+>(config: DefineOberonComponentConfig<Props, FieldMap>): OberonComponent<Props>
+
+export function defineOberonComponent(
+  config: DefineOberonComponentConfig<DefaultComponentProps, OberonFieldMap>,
+): OberonComponent<DefaultComponentProps> {
+  return config
+}
 
 export const clientActions = [
   "edit",

--- a/packages/tohuhono/puck-blocks/src/blocks/container.tsx
+++ b/packages/tohuhono/puck-blocks/src/blocks/container.tsx
@@ -6,11 +6,14 @@ export const Container = {
     className: {
       type: "text",
     },
+    content: {
+      type: "slot",
+    },
   },
-  render: ({ className, puck: { renderDropZone: DropZone } }) => {
+  render: ({ className, content: Content }) => {
     return (
       <div className={cn("flex w-full justify-center p-2", className)}>
-        {<DropZone zone="box" />}
+        {Content?.()}
       </div>
     )
   },

--- a/packages/tohuhono/puck-blocks/src/blocks/container.tsx
+++ b/packages/tohuhono/puck-blocks/src/blocks/container.tsx
@@ -13,7 +13,7 @@ export const Container = {
   render: ({ className, content: Content }) => {
     return (
       <div className={cn("flex w-full justify-center p-2", className)}>
-        {Content?.()}
+        <Content />
       </div>
     )
   },

--- a/packages/tohuhono/puck-blocks/src/example.tsx
+++ b/packages/tohuhono/puck-blocks/src/example.tsx
@@ -1,5 +1,5 @@
-import type { OberonComponent, OberonConfig } from "@oberoncms/core"
-import type { ReactNode } from "react"
+import { defineOberonComponent } from "@oberoncms/core"
+import type { OberonConfig } from "@oberoncms/core"
 import { Container } from "./blocks/container"
 import { Dashboard } from "./dynamic/dashboard"
 import { Welcome } from "./blocks/welcome"
@@ -57,11 +57,7 @@ const cards = {
   },
 }
 
-const Text: OberonComponent<{
-  body?: ReactNode
-  text?: ReactNode
-  className?: string
-}> = {
+const Text = defineOberonComponent({
   fields: {
     text: {
       type: "textarea",
@@ -75,7 +71,7 @@ const Text: OberonComponent<{
     className: "prose dark:prose-invert lg:prose-lg p-2",
   },
   render: ({ text, className }) => <div className={className}>{text}</div>,
-}
+})
 
 export function withExamples(config: Partial<OberonConfig>) {
   return {

--- a/packages/tohuhono/puck-blocks/src/prose.tsx
+++ b/packages/tohuhono/puck-blocks/src/prose.tsx
@@ -1,4 +1,4 @@
-import type { ComponentConfig } from "@puckeditor/core"
+import type { ComponentConfig, SlotComponent } from "@puckeditor/core"
 import { Prose as ProseUI } from "@tohuhono/ui/prose"
 
 export const Prose = {
@@ -6,12 +6,11 @@ export const Prose = {
     className: {
       type: "text",
     },
+    content: {
+      type: "slot",
+    },
   },
-  render: ({ className, puck: { renderDropZone: DropZone } }) => {
-    return (
-      <ProseUI className={className}>
-        <DropZone zone="prose" />
-      </ProseUI>
-    )
+  render: ({ className, content: Content }) => {
+    return <ProseUI className={className}>{Content?.()}</ProseUI>
   },
-} satisfies ComponentConfig<{ className?: string }>
+} satisfies ComponentConfig<{ className?: string; content?: SlotComponent }>

--- a/packages/tohuhono/puck-blocks/src/prose.tsx
+++ b/packages/tohuhono/puck-blocks/src/prose.tsx
@@ -1,7 +1,7 @@
-import type { ComponentConfig, SlotComponent } from "@puckeditor/core"
+import { defineOberonComponent } from "@oberoncms/core"
 import { Prose as ProseUI } from "@tohuhono/ui/prose"
 
-export const Prose = {
+export const Prose = defineOberonComponent({
   fields: {
     className: {
       type: "text",
@@ -11,6 +11,10 @@ export const Prose = {
     },
   },
   render: ({ className, content: Content }) => {
-    return <ProseUI className={className}>{Content?.()}</ProseUI>
+    return (
+      <ProseUI className={className}>
+        <Content />
+      </ProseUI>
+    )
   },
-} satisfies ComponentConfig<{ className?: string; content?: SlotComponent }>
+})

--- a/turbo.json
+++ b/turbo.json
@@ -240,7 +240,7 @@
         "!.next/**",
         "!.playwright/**"
       ],
-      "outputs": [".next/types/**"]
+      "outputs": [".next/types/**", "next-env.d.ts"]
     },
     "wait": {
       "cache": false,


### PR DESCRIPTION
Replace deprecated Puck DropZone usage in shared blocks and infer Oberon component render props from field definitions.