### PR TITLE
Document Better Auth migration impact

### DIFF
--- a/.changeset/lovely-baths-behave.md
+++ b/.changeset/lovely-baths-behave.md
@@ -1,0 +1,46 @@
+---
+"@oberon/docs": minor
+"@oberon/playground": minor
+"@dev/eslint": minor
+"@dev/final": minor
+"@dev/playwright": minor
+"@dev/scripts": minor
+"@dev/typescript": minor
+"@dev/vite": minor
+"@dev/vitest": minor
+"create-oberon-app": minor
+"@oberoncms/core": minor
+"@oberoncms/sqlite": minor
+"@oberoncms/testing": minor
+"@oberoncms/plugin-development": minor
+"@oberoncms/plugin-flydrive": minor
+"@oberoncms/plugin-pgsql": minor
+"@oberoncms/plugin-tailwind": minor
+"@oberoncms/plugin-turso": minor
+"@oberoncms/plugin-uploadthing": minor
+"@tohuhono/puck-blocks": minor
+"@tohuhono/ui": minor
+"@tohuhono/utils": minor
+"@oberon/recipe-nextjs": minor
+---
+
+Promote the repo to the Better Auth model across core packages, plugins, docs,
+recipes, and app scaffolds.
+
+This release removes remaining Auth.js/NextAuth assumptions, standardizes auth
+adapter expectations, and aligns setup guidance around Better Auth as the
+supported path.
+
+Risks and implications:
+
+- Integrations still relying on Auth.js/NextAuth-specific behavior may require
+  configuration and implementation updates.
+- Auth adapter implementations must match the updated user-table/auth contract
+  expectations across sqlite and pgsql paths.
+- Existing user schemas with provider-specific fields may need to be reduced or
+  remapped to the active Better Auth model.
+- Environment variables, callback handling, and session/user lifecycle behavior
+  should be reviewed during upgrade to avoid auth regressions.
+
+Treat this as a coordinated upgrade across core, plugins, recipes, and app
+scaffolds rather than a piecemeal patch.


### PR DESCRIPTION
Add a repo-wide minor changeset that announces the Better Auth migration and highlights upgrade risks across adapters, schemas, and auth flows.